### PR TITLE
KSF-96: Fix wrong redirection '/' to 'sandbox/'

### DIFF
--- a/web/src/main/java/org/kaaproject/kaa/sandbox/service/initialization/KaaSandboxInitializationService.java
+++ b/web/src/main/java/org/kaaproject/kaa/sandbox/service/initialization/KaaSandboxInitializationService.java
@@ -20,7 +20,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.rewrite.handler.RewriteHandler;
-import org.eclipse.jetty.rewrite.handler.RewriteRegexRule;
+import org.eclipse.jetty.rewrite.handler.RedirectRegexRule;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.kaaproject.kaa.server.common.Environment;
 import org.slf4j.Logger;
@@ -41,8 +41,9 @@ public class KaaSandboxInitializationService implements InitializationService {
     private Handler getRedirectRoot2SandboxHandler() {
         RewriteHandler rewrite = new RewriteHandler();
         rewrite.setRewriteRequestURI(true);
+        rewrite.setRewritePathInfo(true);
         
-        RewriteRegexRule redirectRoot = new RewriteRegexRule();
+        RedirectRegexRule redirectRoot = new RedirectRegexRule();
         redirectRoot.setRegex("^/$");
         redirectRoot.setReplacement("/sandbox");
         rewrite.addRule(redirectRoot);


### PR DESCRIPTION
Use redirect instead of rewrite;

(cherry picked from commit 701fb072287d62866f8ac5694454a16182171460)
Merge of #73 to '2016-10-25-21-15-00/KSF-98-app-selection-widget-alignment'
