### PR TITLE
KSF-108: Removed the deprecated compileSourcesArtifacts configuration

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -307,10 +307,6 @@
                     <i18nConstantsWithLookupBundle>org.kaaproject.kaa.sandbox.web.client.i18n.SandboxConstants</i18nConstantsWithLookupBundle>
                     <i18nMessagesBundle>org.kaaproject.kaa.sandbox.web.client.i18n.SandboxMessages</i18nMessagesBundle>
                     <cssFile>org/kaaproject/kaa/sandbox/web/client/SandboxTheme.css</cssFile>
-                    <compileSourcesArtifacts>
-                        <artifact>org.kaaproject.kaa.server.common:dto</artifact>
-                        <artifact>org.kaaproject.kaa.examples:common</artifact>
-                    </compileSourcesArtifacts>
                     <gwtSdkFirstInClasspath>true</gwtSdkFirstInClasspath>
                     <runTarget>Sandbox.html</runTarget>
                     <persistentunitcachedir>${project.build.directory}</persistentunitcachedir>
@@ -609,10 +605,6 @@
 							</execution>
 						</executions>
 						<configuration>
-							<compileSourcesArtifacts>
-								<artifact>org.kaaproject.kaa.server.common:dto</artifact>
-								<artifact>org.kaaproject.kaa.examples:common</artifact>
-							</compileSourcesArtifacts>
 							<gwtSdkFirstInClasspath>true</gwtSdkFirstInClasspath>
 							<runTarget>Sandbox.html</runTarget>
                             <persistentunitcachedir>${project.build.directory}</persistentunitcachedir>


### PR DESCRIPTION
The [deprecated](https://gwt-maven-plugin.github.io/gwt-maven-plugin/compile-mojo.html#compileSourcesArtifacts) compileSourcesArtifacts configuration item was removed. This config is unstable with snapshot artifacts. Use 'sources' classifier for _org.kaaproject.kaa.server.common:dto_ and  _org.kaaproject.kaa.examples:common_ dependencies  instead